### PR TITLE
feat: Add ADFMention class with id and text properties

### DIFF
--- a/atlassian_doc_builder/__init__.py
+++ b/atlassian_doc_builder/__init__.py
@@ -5,6 +5,7 @@ from .adf_object import load_adf
 from .adf_simple import ADFHardBreak, ADFRule
 from .adf_simple import ADFText, ADFDate, ADFPlaceholder
 from .adf_simple import ADFStatus
+from .adf_simple import ADFMention
 
 from .adf_content_node import ADFParagraph, ADFBlockquote, ADFBulletList, ADFOrderList, ADFListItem
 from .adf_content_node import ADFHeading, ADFCodeBlock, ADFPanel, ADFExpand, ADFTaskList, ADFTaskItem

--- a/atlassian_doc_builder/adf_simple.py
+++ b/atlassian_doc_builder/adf_simple.py
@@ -88,3 +88,31 @@ class ADFStatus(ADFObject.node_class_factory('status')):
     @color.setter
     def color(self, value):
         self.assign_info('attrs', color=value)
+
+
+class ADFMention(ADFObject.node_class_factory('mention')):
+    def __init__(self, id_=None, text=None, chain_mode=True, **kwargs):
+        new_kwargs = {k: v for k, v in kwargs.items() if k != 'attrs'}
+        if not id_ and 'id' not in kwargs:
+            raise ValueError('ID cannot be empty.')
+        super(ADFMention, self).__init__(chain_mode=chain_mode, **new_kwargs)
+        self.text = text if text is not None else \
+            kwargs.get('attrs', {}).get('text', '')
+        self.id = id_ if id_ is not None else \
+            kwargs.get('attrs', {}).get('id', '')
+
+    @property
+    def id(self):
+        return self.local_info['id']
+
+    @text.setter
+    def id(self, value):
+        self.assign_info('id', value)
+    
+    @property
+    def text(self):
+        return self.local_info['text']
+
+    @text.setter
+    def text(self, value):
+        self.assign_info('text', value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atlassian-doc-builder"
-version = "0.5.2"
+version = "0.6.0"
 description = "Creating Atlassian Document in a programmatic way."
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
Add support of the `mention` node.

Only `id` and `text` attributes are included.

The following attributes are not included:
- `accessLevel`
- `userType`

Implementing #10 